### PR TITLE
[NOT READY] Change Telemetry Components to use Dependency Incection instead of Service Provider

### DIFF
--- a/src/ApplicationInsights.AspNet/TelemetryInitializers/OperationIdTelemetryInitializer.cs
+++ b/src/ApplicationInsights.AspNet/TelemetryInitializers/OperationIdTelemetryInitializer.cs
@@ -1,21 +1,23 @@
 ﻿namespace Microsoft.ApplicationInsights.AspNet.TelemetryInitializers
 {
-    using System;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.AspNet.Http;
-    using Microsoft.AspNet.Hosting;
+    using Microsoft.ApplicationInsights.Extensibility;
 
-    public class OperationIdTelemetryInitializer : TelemetryInitializerBase
+    public class OperationIdTelemetryInitializer : ITelemetryInitializer
     {
-        public OperationIdTelemetryInitializer(IHttpContextAccessor httpContextAccessor) : base(httpContextAccessor)
-        { }
+        private readonly RequestTelemetry request;
 
-        protected override void OnInitializeTelemetry(HttpContext platformContext, RequestTelemetry requestTelemetry, ITelemetry telemetry)
+        public OperationIdTelemetryInitializer(RequestTelemetry request)
+        {
+            this.request = request;
+        }
+
+        public void Initialize(ITelemetry telemetry)
         {
             if (string.IsNullOrEmpty(telemetry.Context.Operation.Id))
             {
-                telemetry.Context.Operation.Id = requestTelemetry.Id;
+                telemetry.Context.Operation.Id = request.Id;
             }
         }
     }

--- a/test/ApplicationInsights.AspNet.Tests/TelemetryInitializers/OperationIdTelemetryInitializerTest.cs
+++ b/test/ApplicationInsights.AspNet.Tests/TelemetryInitializers/OperationIdTelemetryInitializerTest.cs
@@ -1,51 +1,25 @@
 ﻿namespace Microsoft.ApplicationInsights.AspNet.Tests.TelemetryInitializers
 {
-    using Microsoft.ApplicationInsights.AspNet.TelemetryInitializers;
-    using Microsoft.ApplicationInsights.AspNet.Tests.Helpers;
-    using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.AspNet.Hosting;
-    using Microsoft.AspNet.Http.Core;
     using System;
-    using System.Collections.Generic;
+    using Microsoft.ApplicationInsights.AspNet.TelemetryInitializers;
+    using Microsoft.ApplicationInsights.DataContracts;
     using Xunit;
 
     public class OperationIdTelemetryInitializerTest
     {
         [Fact]
-        public void InitializeThrowIfHttpContextAccessorIsNull()
+        public void ConstructorThrowsIfRequestTelemetryIsNull()
         {
             Assert.Throws<ArgumentNullException>(() => { var initializer = new OperationIdTelemetryInitializer(null); });
         }
 
         [Fact]
-        public void InitializeDoesNotThrowIfHttpContextIsUnavailable()
-        {
-            var ac = new HttpContextAccessor() { Value = null };
-
-            var initializer = new OperationIdTelemetryInitializer(ac);
-
-            initializer.Initialize(new RequestTelemetry());
-        }
-
-        [Fact]
-        public void InitializeDoesNotThrowIfRequestTelemetryIsUnavailable()
-        {
-            var ac = new HttpContextAccessor() { Value = new DefaultHttpContext() };
-
-            var initializer = new OperationIdTelemetryInitializer(ac);
-
-            initializer.Initialize(new RequestTelemetry());
-        }
-
-        [Fact]
         public void InitializeDoesNotOverrideOperationIdProvidedInline()
         {
+            var initializer = new OperationIdTelemetryInitializer(new RequestTelemetry());
+
             var telemetry = new EventTelemetry();
             telemetry.Context.Operation.Id = "123";
-            var ac = new HttpContextAccessor() { Value = new DefaultHttpContext() };
-            ac.Value.RequestServices = new TestServiceProvider(new List<object>() { new RequestTelemetry() });
-            var initializer = new OperationIdTelemetryInitializer(ac);
-
             initializer.Initialize(telemetry);
 
             Assert.Equal("123", telemetry.Context.Operation.Id);
@@ -54,15 +28,13 @@
         [Fact]
         public void InitializeSetsTelemetryOperationIdToRequestId()
         {
-            var telemetry = new EventTelemetry();
-            var requestTelemetry = new RequestTelemetry();
-            var ac = new HttpContextAccessor() { Value = new DefaultHttpContext() };
-            ac.Value.RequestServices = new TestServiceProvider(new List<object>() { requestTelemetry });
-            var initializer = new OperationIdTelemetryInitializer(ac);
+            var request = new RequestTelemetry { Id = "123" };
+            var initializer = new OperationIdTelemetryInitializer(request);
 
+            var telemetry = new EventTelemetry();
             initializer.Initialize(telemetry);
 
-            Assert.Equal(requestTelemetry.Id, telemetry.Context.Operation.Id);
+            Assert.Equal(request.Id, telemetry.Context.Operation.Id);
         }
     }
 }


### PR DESCRIPTION
According to the ASP.NET team, automatic dependency injection is preferable to explicit dependency resolution from service provider. This set of changes converts Application Insights telemetry components to conform with this design. 

TO-DO:
* Change TelemetryConfiguration service from application to request scope *or* introduce TelemetryClient constructor that takes individual components instead of TelemetryConfiguration. This is necessary to allow telemetry and context initializers to be request-scoped services. TelemetryConfiguration is expensive (it uses snapshot collections) and meant to be application-scoped. 