### PR TITLE
Fix dependencies so fresh builds will work out-of-the box

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <add key="ASP.NET 5" value="https://www.myget.org/F/aspnetrelease/api/v2/" />
-    <add key="ASP.NET 5 Dev" value="\\projectk-tc\drops\Coherence-Signed\dev\latest\Packages-NoTimeStamp" />
+    <!-- <add key="ASP.NET 5 Dev" value="\\projectk-tc\drops\Coherence-Signed\dev\latest\Packages-NoTimeStamp" /> -->
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
   </packageSources>
 </configuration>

--- a/src/Microsoft.ApplicationInsights.AspNet/project.json
+++ b/src/Microsoft.ApplicationInsights.AspNet/project.json
@@ -5,17 +5,18 @@
     "version": "1.0.0-beta5",
     "copyright": "Copyright © Microsoft. All Rights Reserved.",
     "projectUrl": "https://github.com/Microsoft/ApplicationInsights-aspnet5",
-    "licenseUrl": "http://go.microsoft.com/fwlink/?LinkID=510709", 
+    "licenseUrl": "http://go.microsoft.com/fwlink/?LinkID=510709",
     "requireLicenseAcceptance": true,
     "iconUrl": "http://appanacdn.blob.core.windows.net/cdn/icons/aic.png",
     "tags": [ "Analytics", "ApplicationInsights", "Telemetry", "AppInsights", "ASP.NET 5" ],
     "dependencies": {
         "Microsoft.ApplicationInsights": "0.17.1-beta",
-        "Microsoft.AspNet.Hosting.Abstractions": "1.0.0-beta5",        
-        "Microsoft.AspNet.Http.Abstractions": "1.0.0-beta5",
-        "Microsoft.AspNet.Mvc": "6.0.0-beta5",
-        "Microsoft.Framework.Logging.Abstractions": "1.0.0-beta5",
-        "Microsoft.Framework.Configuration": "1.0.0-beta5"
+        "Microsoft.AspNet.Hosting.Abstractions": "1.0.0-beta5-*",
+        "Microsoft.AspNet.Http.Abstractions": "1.0.0-beta5-*",
+        "Microsoft.AspNet.Http.Features": "1.0.0-beta5-*",
+        "Microsoft.AspNet.Mvc": "6.0.0-beta5-*",
+        "Microsoft.Framework.Logging.Abstractions": "1.0.0-beta5-*",
+        "Microsoft.Framework.Configuration": "1.0.0-beta5-*"
     },
 
     "frameworks": {


### PR DESCRIPTION
update NuGet.conf to not point to unreachable repository, and update dependencies in project.json to latest beta5, instead of oldest beta5.  Applies to Microsoft/ApplicationInsights-aspnet5#84