### PR TITLE
allow monitoring of non-MVC apps

### DIFF
--- a/ApplicationInsights.AspNet.sln
+++ b/ApplicationInsights.AspNet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23102.2
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{2E6DDE9E-8C75-4F9C-8906-08EBDD6E73EF}"
 EndProject
@@ -34,6 +34,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "StartupPerf", "StartupPerf"
 		test\StartupPerf\startupPerf.ps1 = test\StartupPerf\startupPerf.ps1
 	EndProjectSection
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "EmptyApp.FunctionalTests", "test\EmptyApp.FunctionalTests\EmptyApp.FunctionalTests.xproj", "{71CE2DB2-C7AA-4454-B5F2-774BC575E321}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -60,6 +62,10 @@ Global
 		{11FB2EE6-7199-4AFF-BC73-25F35675F233}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{11FB2EE6-7199-4AFF-BC73-25F35675F233}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{11FB2EE6-7199-4AFF-BC73-25F35675F233}.Release|Any CPU.Build.0 = Release|Any CPU
+		{71CE2DB2-C7AA-4454-B5F2-774BC575E321}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{71CE2DB2-C7AA-4454-B5F2-774BC575E321}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{71CE2DB2-C7AA-4454-B5F2-774BC575E321}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{71CE2DB2-C7AA-4454-B5F2-774BC575E321}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -71,5 +77,6 @@ Global
 		{B7217A00-66FA-49A8-8EF3-39C07E1F7E33} = {8B5230E5-8138-44D6-839F-DF9248F195EE}
 		{11FB2EE6-7199-4AFF-BC73-25F35675F233} = {8B5230E5-8138-44D6-839F-DF9248F195EE}
 		{16B44D67-6214-4DDE-B419-93EF073E2E69} = {8B5230E5-8138-44D6-839F-DF9248F195EE}
+		{71CE2DB2-C7AA-4454-B5F2-774BC575E321} = {8B5230E5-8138-44D6-839F-DF9248F195EE}
 	EndGlobalSection
 EndGlobal

--- a/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/OperationNameTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights.AspNet/TelemetryInitializers/OperationNameTelemetryInitializer.cs
@@ -20,12 +20,15 @@
         public OperationNameTelemetryInitializer(IHttpContextAccessor httpContextAccessor, INotifier notifier) 
             : base(httpContextAccessor)
         {
-            if (notifier == null)
+            if (notifier != null)
             {
-                throw new ArgumentNullException("notifier");
+                notifier.EnlistTarget(this);
             }
+        }
 
-            notifier.EnlistTarget(this);
+        public OperationNameTelemetryInitializer(IHttpContextAccessor httpContextAccessor)
+            : this(httpContextAccessor, null)
+        {
         }
 
         protected override void OnInitializeTelemetry(HttpContext platformContext, RequestTelemetry requestTelemetry, ITelemetry telemetry)

--- a/test/EmptyApp.FunctionalTests/EmptyApp.FunctionalTests.xproj
+++ b/test/EmptyApp.FunctionalTests/EmptyApp.FunctionalTests.xproj
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>71ce2db2-c7aa-4454-b5f2-774bc575e321</ProjectGuid>
+    <RootNamespace>EmptyApp.FunctionalTests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+    <DevelopmentServerPort>6556</DevelopmentServerPort>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/EmptyApp.FunctionalTests/FunctionalTest/ExceptionTelemetryTests.cs
+++ b/test/EmptyApp.FunctionalTests/FunctionalTest/ExceptionTelemetryTests.cs
@@ -1,0 +1,44 @@
+﻿namespace EmptyApp.FunctionalTests.FunctionalTest
+{
+    using System;
+    using FunctionalTestUtils;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Xunit;
+
+    public class ExceptionTelemetryTests : TelemetryTestsBase
+    {
+        private const string assemblyName = "EmptyApp.FunctionalTests";
+
+        [Fact]
+        public void TestBasicRequestPropertiesAfterRequestingRequestThatThrows()
+        {
+            using (var server = new InProcessServer(assemblyName))
+            {
+                const string RequestPath = "/Exception";
+
+                var expectedRequestTelemetry = new RequestTelemetry();
+                expectedRequestTelemetry.HttpMethod = "GET";
+
+                // Request name is tracked incorretly in case of errors right now, tracked by https://github.com/Microsoft/ApplicationInsights-aspnet5/issues/91
+                expectedRequestTelemetry.Name = "GET /Exception";
+                expectedRequestTelemetry.ResponseCode = "500";
+                expectedRequestTelemetry.Success = false;
+                expectedRequestTelemetry.Url = new System.Uri(server.BaseHost + RequestPath);
+                this.ValidateBasicRequest(server, "/Exception", expectedRequestTelemetry);
+            }
+        }
+
+        [Fact]
+        public void TestBasicExceptionPropertiesAfterRequestingRequestThatThrows()
+        {
+            using (var server = new InProcessServer(assemblyName))
+            {
+                var expectedExceptionTelemetry = new ExceptionTelemetry();
+                expectedExceptionTelemetry.HandledAt = ExceptionHandledAt.Platform;
+                expectedExceptionTelemetry.Exception = new InvalidOperationException();
+
+                this.ValidateBasicException(server, "/Exception", expectedExceptionTelemetry);
+            }
+        }
+    }
+}

--- a/test/EmptyApp.FunctionalTests/FunctionalTest/RequestTelemetryTests.cs
+++ b/test/EmptyApp.FunctionalTests/FunctionalTest/RequestTelemetryTests.cs
@@ -1,0 +1,71 @@
+﻿namespace EmptyApp.FunctionalTests.FunctionalTest
+{
+    using System.Linq;
+    using System.Net.Http;
+    using FunctionalTestUtils;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Xunit;
+
+    public class RequestTelemetryTests : TelemetryTestsBase
+    {
+        private const string assemblyName = "EmptyApp.FunctionalTests";
+
+        [Fact]
+        public void TestBasicRequestPropertiesAfterRequestingBasicPage()
+        {
+            using (var server = new InProcessServer(assemblyName))
+            {
+                const string RequestPath = "/";
+
+                var expectedRequestTelemetry = new RequestTelemetry();
+                expectedRequestTelemetry.HttpMethod = "GET";
+                expectedRequestTelemetry.Name = "GET /";
+                expectedRequestTelemetry.ResponseCode = "200";
+                expectedRequestTelemetry.Success = true;
+                expectedRequestTelemetry.Url = new System.Uri(server.BaseHost + RequestPath);
+
+                this.ValidateBasicRequest(server, RequestPath, expectedRequestTelemetry);
+            }
+        }
+
+        [Fact]
+        public void TestBasicRequestPropertiesAfterRequestingNotExistingPage()
+        {
+            using (var server = new InProcessServer(assemblyName))
+            {
+                const string RequestPath = "/not/existing/controller";
+
+                var expectedRequestTelemetry = new RequestTelemetry();
+                expectedRequestTelemetry.HttpMethod = "GET";
+                expectedRequestTelemetry.Name = "GET /not/existing/controller";
+                expectedRequestTelemetry.ResponseCode = "404";
+                expectedRequestTelemetry.Success = false;
+                expectedRequestTelemetry.Url = new System.Uri(server.BaseHost + RequestPath);
+
+                this.ValidateBasicRequest(server, RequestPath, expectedRequestTelemetry);
+            }
+        }
+
+        [Fact]
+        public void TestMixedTelemetryItemsReceived()
+        {
+            using (var server = new InProcessServer(assemblyName))
+            {
+                var httpClient = new HttpClient();
+                var task = httpClient.GetAsync(server.BaseHost + "/Mixed");
+                task.Wait(TestTimeoutMs);
+
+                var request = server.BackChannel.Buffer.OfType<RequestTelemetry>().Single();
+                var eventTelemetry = server.BackChannel.Buffer.OfType<EventTelemetry>().Single();
+                var metricTelemetry = server.BackChannel.Buffer.OfType<MetricTelemetry>().Single();
+                var traceTelemetry = server.BackChannel.Buffer.OfType<TraceTelemetry>().Single();
+
+                Assert.Equal(4, server.BackChannel.Buffer.Count);
+                Assert.NotNull(request);
+                Assert.NotNull(eventTelemetry);
+                Assert.NotNull(metricTelemetry);
+                Assert.NotNull(traceTelemetry);
+            }
+        }
+    }
+}

--- a/test/EmptyApp.FunctionalTests/Startup.cs
+++ b/test/EmptyApp.FunctionalTests/Startup.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.Http;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.ApplicationInsights.AspNet.Extensions;
+using Microsoft.Framework.Configuration;
+using Microsoft.Framework.Configuration.Memory;
+using Microsoft.ApplicationInsights.Channel;
+using FunctionalTestUtils;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.AspNet.Diagnostics;
+
+namespace EmptyApp.FunctionalTests
+{
+    public class Startup
+    {
+        // For more information on how to configure your application, visit http://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddInstance<ITelemetryChannel>(new BackTelemetryChannel());
+
+            var builder = new ConfigurationBuilder();
+            builder.AddApplicationInsightsSettings(instrumentationKey: "Foo");
+            services.AddApplicationInsightsTelemetry(builder.Build());
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseApplicationInsightsRequestTelemetry();
+            app.UseErrorPage(new ErrorPageOptions());
+            app.UseApplicationInsightsExceptionTelemetry();
+
+            app.Use(next =>
+            {
+                return async context =>
+                {
+                    if (context.Request.GetUri().ToString().Contains("Exception"))
+                    {
+                        throw new InvalidOperationException();
+                    }
+                    else if (context.Request.GetUri().PathAndQuery == "/")
+                    {
+                        await context.Response.WriteAsync("Hello!");
+                    }
+                    else if (context.Request.GetUri().ToString().Contains("Mixed"))
+                    {
+                        TelemetryClient telemetryClient = (TelemetryClient)context.RequestServices.GetService(typeof(TelemetryClient));
+                        telemetryClient.TrackEvent("GetContact");
+                        telemetryClient.TrackMetric("ContactFile", 1);
+                        telemetryClient.TrackTrace("Fetched contact details.", SeverityLevel.Information);
+                        await context.Response.WriteAsync("Hello!");
+                    }
+                    else
+                    {
+                        await next(context);
+                    }
+                };
+            });
+        }
+    }
+}

--- a/test/EmptyApp.FunctionalTests/hosting.ini
+++ b/test/EmptyApp.FunctionalTests/hosting.ini
@@ -1,0 +1,2 @@
+﻿server=Microsoft.AspNet.Server.WebListener
+server.urls=http://localhost:5000

--- a/test/EmptyApp.FunctionalTests/project.json
+++ b/test/EmptyApp.FunctionalTests/project.json
@@ -1,0 +1,36 @@
+﻿{
+  "webroot": "wwwroot",
+  "version": "1.0.0-*",
+
+  "dependencies": {
+    "Microsoft.AspNet.Server.IIS": "1.0.0-beta7",
+    "Microsoft.AspNet.Server.WebListener": "1.0.0-beta7",
+    "Microsoft.ApplicationInsights.AspNet": "1.0.0-beta7-*",
+    "FunctionalTestUtils": "1.0.0-beta7-*",
+    "xunit.runner.aspnet": "2.0.0-aspnet-beta7-*",
+    "Microsoft.AspNet.Diagnostics": "1.0.0-beta7-*"
+  },
+
+  "commands": {
+    "web": "Microsoft.AspNet.Hosting --config hosting.ini",
+    "test": "xunit.runner.aspnet"
+  },
+
+  "frameworks": {
+    "dnx451": { },
+    "dnxcore50": { }
+  },
+
+  "publishExclude": [
+    "node_modules",
+    "bower_components",
+    "**.xproj",
+    "**.user",
+    "**.vspscc"
+  ],
+  "exclude": [
+    "wwwroot",
+    "node_modules",
+    "bower_components"
+  ]
+}

--- a/test/FunctionalTestUtils/project.json
+++ b/test/FunctionalTestUtils/project.json
@@ -3,10 +3,7 @@
     "dependencies": {
         "Microsoft.ApplicationInsights": "1.1.1-beta",
         "Microsoft.ApplicationInsights.AspNet": "1.0.0-beta7",
-        "Microsoft.AspNet.Diagnostics": "1.0.0-beta7-*",
-        "Microsoft.AspNet.Hosting": "1.0.0-beta7-*",
         "Microsoft.AspNet.Http.Abstractions": "1.0.0-beta7-*",
-        "Microsoft.AspNet.Mvc": "6.0.0-beta7-*",
         "Microsoft.AspNet.Server.WebListener": "1.0.0-beta7-*",
         "Microsoft.Dnx.Runtime": "1.0.0-beta7-*",
         "Microsoft.Net.Http.Client": "1.0.0-*",

--- a/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/OperationNameTelemetryInitializerTests.cs
+++ b/test/Microsoft.ApplicationInsights.AspNet.Tests/TelemetryInitializers/OperationNameTelemetryInitializerTests.cs
@@ -24,14 +24,6 @@
         }
 
         [Fact]
-        public void InitializeThrowIfNotifierIsNull()
-        {
-            var ac = new HttpContextAccessor() { HttpContext = null };
-
-            Assert.Throws<ArgumentNullException>(() => { var initializer = new OperationNameTelemetryInitializer(ac, null); });
-        }
-
-        [Fact]
         public void InitializeDoesNotThrowIfHttpContextIsUnavailable()
         {
             var ac = new HttpContextAccessor() { HttpContext = null };


### PR DESCRIPTION
Fixing https://github.com/Microsoft/ApplicationInsights-aspnet5/issues/112